### PR TITLE
WedosWAPI: force Europe/Prague timezone

### DIFF
--- a/wedos-dns01/WedosWapi.php
+++ b/wedos-dns01/WedosWapi.php
@@ -15,6 +15,7 @@ class WedosWapi {
 	 * @return string
 	 */
 	private function generateHash() {
+		date_default_timezone_set("Europe/Prague");
 		return sha1($this->login . sha1($this->wapiPass) . date('H', time()));
 	}
 


### PR DESCRIPTION
"Časové pásmo je Europe/Prague (zimní čas UTC+1 SEČ,
letní čas UTC+2 SELČ)." - https://kb.wedos.com/cs/wapi/komunikace.html

Fixes: https://github.com/Ashus/letsencrypt-wedos/issues/5
Signed-off-by: David Heidelberg <david@ixit.cz>